### PR TITLE
Add tts enable/disable toggles

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,23 @@ In OBS, add a new source to your scene of type `Browser`. In the `URL` field, ty
 Replace `YourTwitchUsername` with your actual Twitch username.
 *Note*: this source needs to be in every scene where you want TTS.
 
+### Chat Commands
+
+Use chat commands to control the service:
+
+- `!tts on` – enable text-to-speech.
+- `!tts off` – disable text-to-speech (no messages are sent to OpenAI).
+- `!tts voice <1-6>` – change your voice.
+- `!ttsbits <n>` – set the bit price for TTS messages.
+- `!tts emotes on` / `!tts emotes off` – toggle reading emotes.
+- `!tts ban <username>` – ban a user from TTS.
+- `!tts unban <username>` – unban a user from TTS.
+- `!tts banlist` – list banned users.
+- `!tts let <username>` – allow a user to bypass TTS restrictions.
+- `!tts letlist` – list users who are allowed.
+- `!tts charlimit <n>` – set the character limit (0–500).
+- `!tts help` – list all TTS commands.
+
 ## For programmers: Building Instructions
 If you want to run the server yourself, 
 - install the dependancies with `npm install`,


### PR DESCRIPTION
## Summary
- put `!tts on/off` at the top of `!tts help` and add `!tts charlimit`
- simplify TTS toggle check by assuming channel config exists
- document every TTS command in the README
- ping OBS browser clients and auto-reconnect when the WebSocket closes

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a533c0cc508326bcc2b2d1c44c1127